### PR TITLE
provide the Enumerator's size when known

### DIFF
--- a/lib/epitools/core_ext/enumerable.rb
+++ b/lib/epitools/core_ext/enumerable.rb
@@ -190,7 +190,7 @@ module Enumerable
     queue = Queue.new
     each { |e| queue.push e }
 
-    Enumerator.new do |y|
+    Enumerator.new(queue.size) do |y|
       workers = (0...num_workers).map do
         Thread.new do
           begin
@@ -569,7 +569,7 @@ class Enumerator
   def +(other)
     raise "Can only concatenate Enumerable things to Enumerators" unless Enumerable === other
 
-    Enumerator.new do |yielder|
+    Enumerator.new(count + other.count) do |yielder|
       each { |e| yielder << e }
       other.each { |e| yielder << e }
     end
@@ -601,7 +601,7 @@ class Enumerator
   # returning a new Enumerator. (The argument must be some kind of Enumerable.)
   #
   def cross_product(other)
-    Enumerator.new do |yielder|
+    Enumerator.new(count + other.count) do |yielder|
       each { |a| other.each { |b| yielder << [a,b] } }
     end
   end

--- a/spec/core_ext_spec.rb
+++ b/spec/core_ext_spec.rb
@@ -674,9 +674,11 @@ describe Enumerator do
   it "concatenates" do
     e = [1,2,3].to_enum + [4,5,6].to_enum
     e.to_a.should == [1,2,3,4,5,6]
+    e.size.should == 6
 
     e = [1,2,3].to_enum + [4,5,6]
     e.to_a.should == [1,2,3,4,5,6]
+    e.size.should == 6
   end
 
   it "multiplies" do


### PR DESCRIPTION
For the Queue, passing on the size onto the Enumerator seems like an easy win.

I'm not sure if it's acceptable to count each Enumerable for #+ and #cross_product up front, but if it is, it'd provide a quick #size.